### PR TITLE
Fix case issue with name and symbol lookup

### DIFF
--- a/geoip2.gemspec
+++ b/geoip2.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.name         = 'geoip2'
+  s.name         = 'GeoIP2'
   s.version      = "0.0.5"
   s.licenses     = ['WTFPL']
 


### PR DESCRIPTION
Without this, we get errors on OS X regarding Init_geoip2 being called instead of Init_GeoIP2.
