### PR TITLE
Subdivisions

### DIFF
--- a/geoip2.c
+++ b/geoip2.c
@@ -95,7 +95,8 @@ VALUE mGeoIP2_locate(int argc, VALUE *argv, VALUE self)
             rb_hash_aset(locate_result, rb_str_new2("country"), locate_by_path(&result, "country names", lang));
             rb_hash_aset(locate_result, rb_str_new2("country_code"), locate_by_path(&result, "country iso_code", NULL));
             rb_hash_aset(locate_result, rb_str_new2("continent"), locate_by_path(&result, "continent names", lang));
-            //rb_hash_aset(locate_result, rb_str_new2("subdivision"), locate_by_path(&result, "subdivisions names", lang));
+            rb_hash_aset(locate_result, rb_str_new2("subdivision"), locate_by_path(&result, "subdivisions 0 names", lang));
+            rb_hash_aset(locate_result, rb_str_new2("subdivision_code"), locate_by_path(&result, "subdivisions 0 iso_code", NULL));
             rb_hash_aset(locate_result, rb_str_new2("latitude"), locate_by_path(&result, "location latitude", NULL));
             rb_hash_aset(locate_result, rb_str_new2("longitude"), locate_by_path(&result, "location longitude", NULL));
         }


### PR DESCRIPTION
Added support for handling a single subdivision and subdivision code:

``` ruby
irb> look_up "20.20.20.20" # subdivision known
  => {:city=>"Falls Church", :subdivision=>"Virginia", :country=>"United States", :latitude=>38.864, :continent=>"North America", :country_code=>"US", :longitude=>-77.1922, :subdivision_code=>"VA"}

irb> look_up "4.5.6.7" # no subdivision known
  => {:city=>nil, :subdivision=>nil, :country=>"United States", :latitude=>38.0, :continent=>"North America", :country_code=>"US", :longitude=>-97.0, :subdivision_code=>nil}
```
