### PR TITLE
Allow using CC to specify compiler

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -4,6 +4,8 @@ extension_name = 'geoip2'
 $LDFLAGS << "#{ENV['LDFLAGS']}"
 $CFLAGS << "#{ENV['CFLAGS']}"
 
+RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
+
 if have_header('maxminddb.h') and have_library('maxminddb')
   create_makefile(extension_name)
 else


### PR DESCRIPTION
This fixes #7 by allowing users to specify a compiler to use when installing
the gem.

```
CC=gcc gem install geoip2-0.0.8.gem
```
