### PR TITLE
Add a space so additional flags don’t conflict with existing flags

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -1,8 +1,8 @@
 require 'mkmf'
 extension_name = 'geoip2'
 
-$LDFLAGS << "#{ENV['LDFLAGS']}"
-$CFLAGS << "#{ENV['CFLAGS']}"
+$LDFLAGS << " #{ENV['LDFLAGS']}"
+$CFLAGS << " #{ENV['CFLAGS']}"
 
 RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 


### PR DESCRIPTION
Without this I receive the error below. The flags in ENV were being added to an existing flag causing it to be incorrect. The space fixes that.

```
❯ ruby extconf.rb
checking for maxminddb.h... /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:456:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:587:in `try_cpp'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:1067:in `block in have_header'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:918:in `block in checking_for'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:351:in `block (2 levels) in postpone'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:321:in `open'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:351:in `block in postpone'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:321:in `open'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:347:in `postpone'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:917:in `checking_for'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/2.1.0/mkmf.rb:1066:in `have_header'
        from extconf.rb:9:in `<main>'
```
