### PR TITLE
Rename project to maxmind_geoip2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ruby GeoIP2 Bindings
+# Ruby Maxmind GeoIP2 Bindings
 
 ## Description
 
@@ -11,7 +11,7 @@ Use it with rails. For now, I think.
 [libmaxminddb](https://github.com/maxmind/libmaxminddb) must be installed.
 
 ```
-gem 'geoip2', github: 'da4nik/geoip2'
+gem 'maxmind_geoip2'
 ```
 
 ## Usage
@@ -19,8 +19,8 @@ gem 'geoip2', github: 'da4nik/geoip2'
 ### Configuration, can be moved to rails initializer
 
 ```ruby
-GeoIP2::file '<local_db_file.mmdb>' # default: GeoLite2-City.mmdb
-GeoIP2::locale 'ru' # default: 'ru'
+MaxmindGeoIP2.file '<local_db_file.mmdb>' # default: GeoLite2-City.mmdb
+MaxmindGeoIP2.locale 'ru' # default: 'ru'
 ```
 
 ### Further usage:
@@ -28,9 +28,9 @@ GeoIP2::locale 'ru' # default: 'ru'
 Returns nil if nothing found and raises exception if file not opened or not found
 
 ```ruby
-city = GeoIP2::locate(<ip address>, <optional lang>)
+city = MaxmindGeoIP2.locate(<ip address>, <optional lang>)
 
-city = GeoIP2::locate '77.93.127.33'
+city = MaxmindGeoIP2.locate '77.93.127.33'
 => {"city"=>"Тамбов",
 "city_geoname_id"=>484646,
 "country"=>"Россия",
@@ -46,7 +46,7 @@ city = GeoIP2::locate '77.93.127.33'
 "longitude"=>41.4433,
 "time_zone"=>"Europe/Moscow"}
 
-city = GeoIP2::locate '77.93.127.33', 'en'
+city = MaxmindGeoIP2.locate '77.93.127.33', 'en'
 => {"city"=>"Tambov",
 "city_geoname_id"=>484646,
 "country"=>"Russia",

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 require "rake/extensiontask"
 require 'rake/testtask'
 
-Rake::ExtensionTask.new "geoip2" do |ext|
-  ext.lib_dir = "lib/geoip2"
+Rake::ExtensionTask.new "maxmind_geoip2" do |ext|
+  ext.lib_dir = "lib/maxmind_geoip2"
 end
 
 Rake::TestTask.new do |t|
@@ -24,8 +24,8 @@ end
 desc "An IRB console with the project loaded"
 task :console do
   $: << 'lib'
-  require 'geoip2'
-  GeoIP2.file('GeoLite2-City.mmdb')
+  require 'maxmind_geoip2'
+  MaxmindGeoIP2.file('GeoLite2-City.mmdb')
   require 'irb'
   require 'irb/completion'
   ARGV.clear

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "rake/extensiontask"
 require 'rake/testtask'
+require 'bundler'
+Bundler::GemHelper.install_tasks
 
 Rake::ExtensionTask.new "maxmind_geoip2" do |ext|
   ext.lib_dir = "lib/maxmind_geoip2"

--- a/ext/maxmind_geoip2/extconf.rb
+++ b/ext/maxmind_geoip2/extconf.rb
@@ -1,5 +1,5 @@
 require 'mkmf'
-extension_name = 'geoip2'
+extension_name = 'maxmind_geoip2'
 
 $LDFLAGS << " #{ENV['LDFLAGS']}"
 $CFLAGS << " #{ENV['CFLAGS']}"

--- a/ext/maxmind_geoip2/maxmind_geoip2.c
+++ b/ext/maxmind_geoip2/maxmind_geoip2.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <errno.h>
 
-VALUE mGeoIP2 = Qnil;
+VALUE mMaxmindGeoIP2 = Qnil;
 
 const char **lookup_path_parse(char *lookup_path, char *lang)
 {
@@ -60,7 +60,7 @@ VALUE locate_by_path(MMDB_lookup_result_s *result, char *lookup_path, char *lang
     return return_value;
 }
 
-VALUE mGeoIP2_locate(int argc, VALUE *argv, VALUE self)
+VALUE mMaxmindGeoIP2_locate(int argc, VALUE *argv, VALUE self)
 {
     VALUE locate_result = Qnil;
 
@@ -123,28 +123,28 @@ VALUE mGeoIP2_locate(int argc, VALUE *argv, VALUE self)
     return locate_result;
 }
 
-VALUE mGeoIP2_file(VALUE self, VALUE filepath)
+VALUE mMaxmindGeoIP2_file(VALUE self, VALUE filepath)
 {
     rb_iv_set(self, "@_file", filepath);
     return Qtrue;
 }
 
-VALUE mGeoIP2_locale(VALUE self, VALUE language)
+VALUE mMaxmindGeoIP2_locale(VALUE self, VALUE language)
 {
     rb_iv_set(self, "@_locale", language);
     return Qtrue;
 }
 
-void Init_geoip2()
+void Init_maxmind_geoip2()
 {
-      mGeoIP2 = rb_define_module("GeoIP2");
-      rb_define_module_function(mGeoIP2, "locate", mGeoIP2_locate, -1);
-      rb_define_module_function(mGeoIP2, "file", mGeoIP2_file, 1);
-      rb_define_module_function(mGeoIP2, "locale", mGeoIP2_locale, 1);
+      mMaxmindGeoIP2 = rb_define_module("MaxmindGeoIP2");
+      rb_define_module_function(mMaxmindGeoIP2, "locate", mMaxmindGeoIP2_locate, -1);
+      rb_define_module_function(mMaxmindGeoIP2, "file", mMaxmindGeoIP2_file, 1);
+      rb_define_module_function(mMaxmindGeoIP2, "locale", mMaxmindGeoIP2_locale, 1);
 
-      rb_define_attr(mGeoIP2, "_file", 1, 1);
-      rb_define_attr(mGeoIP2, "_locale", 1, 1);
+      rb_define_attr(mMaxmindGeoIP2, "_file", 1, 1);
+      rb_define_attr(mMaxmindGeoIP2, "_locale", 1, 1);
 
-      rb_iv_set(mGeoIP2, "@_file", rb_str_new2("GeoLite2-City.mmdb"));
-      rb_iv_set(mGeoIP2, "@_locale", rb_str_new2("ru"));
+      rb_iv_set(mMaxmindGeoIP2, "@_file", rb_str_new2("GeoLite2-City.mmdb"));
+      rb_iv_set(mMaxmindGeoIP2, "@_locale", rb_str_new2("ru"));
 }

--- a/lib/geoip2.rb
+++ b/lib/geoip2.rb
@@ -1,1 +1,0 @@
-require 'geoip2/geoip2'

--- a/lib/maxmind_geoip2.rb
+++ b/lib/maxmind_geoip2.rb
@@ -1,0 +1,1 @@
+require 'maxmind_geoip2/maxmind_geoip2'

--- a/maxmind_geoip2.gemspec
+++ b/maxmind_geoip2.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.name         = 'geoip2'
+  s.name         = 'maxmind_geoip2'
   s.version      = "0.0.8"
 
   s.licenses     = ['WTFPL']
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage     = "http://github.com"
 
   s.files        = `git ls-files`.split("\n")
-  s.extensions   = ['ext/geoip2/extconf.rb']
+  s.extensions   = ['ext/maxmind_geoip2/extconf.rb']
   s.require_paths = ["lib"]
 
   s.add_development_dependency 'rake', '~>10.0'

--- a/spec/maxmind_geoip2_spec.rb
+++ b/spec/maxmind_geoip2_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe GeoIP2 do
+describe MaxmindGeoIP2 do
   describe '.locate' do
-    let(:result) { GeoIP2.locate('74.125.237.168') }
+    let(:result) { MaxmindGeoIP2.locate('74.125.237.168') }
 
     it 'sets string encodings to utf8' do
       result['country'].encoding.must_equal(Encoding::UTF_8)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 require 'bundler/setup'
 require 'minitest/autorun'
 
-require 'geoip2'
+require 'maxmind_geoip2'
 
 unless File.exist?('GeoLite2-City.mmdb')
   raise "GeoLite2-City.mmdb doesn't exist. Run rake download_free_database to get it"
 end
 
-GeoIP2.file('GeoLite2-City.mmdb')
+MaxmindGeoIP2.file('GeoLite2-City.mmdb')


### PR DESCRIPTION
Since `geoip2` is [already taken on rubygems.org](https://rubygems.org/gems/geoip2), how would you feel about renaming the project and publishing a gem?

The PR makes all the necessary changes to rename the project to `maxmind_geoip2`. Happy to rename to something else if you prefer though... `rake release` should be all that is required to publish the gem to rubygems.